### PR TITLE
Restricted negative values/sign in weight and height user input

### DIFF
--- a/src/components/BmiForm/BmiForm.jsx
+++ b/src/components/BmiForm/BmiForm.jsx
@@ -5,8 +5,10 @@ import '../App/App.css';
 const initialValues = {
 	weight: '',
 	height: '',
-	date: ''
+	date: '',
 }
+
+const restrictKeyList = ['-', '+'];
 
 const BmiForm = ({ change }) => {
 	const [state, setState] = useState(initialValues);
@@ -24,6 +26,11 @@ const BmiForm = ({ change }) => {
 		});
 	};
 
+	const filterInput = (e, restrictKeyList) => {
+		let isValidInput = restrictKeyList.some((key) => e.key === key);
+		if (isValidInput) e.preventDefault();
+	};
+
 	const handleSubmit = () => {
 		change(state);
 		setState(initialValues);
@@ -35,14 +42,15 @@ const BmiForm = ({ change }) => {
 				<div className="col m6 s12">
 					<label htmlFor="weight">Weight (in kg)</label>
 					<input
-						id="weight"
+						id="number1"
 						name="weight"
 						type="number"
-						min="1"
-						max="999"
+						max={999}
+						min={1}
 						placeholder="50"
 						value={state.weight}
-						onChange={handleChange}
+						onChange={(e) => handleChange(e)}
+						onKeyDown={(e) => filterInput(e, restrictKeyList)}
 					/>
 				</div>
 
@@ -57,6 +65,7 @@ const BmiForm = ({ change }) => {
 						placeholder="176"
 						value={state.height}
 						onChange={handleChange}
+						onKeyDown={(e) => filterInput(e, restrictKeyList)}
 					/>
 				</div>
 			</div>
@@ -76,7 +85,7 @@ const BmiForm = ({ change }) => {
 };
 
 BmiForm.propTypes = {
-	change: PropTypes.func.isRequired
+	change: PropTypes.func.isRequired,
 };
 
 export default BmiForm;

--- a/src/components/BmiForm/BmiForm.jsx
+++ b/src/components/BmiForm/BmiForm.jsx
@@ -5,9 +5,8 @@ import '../App/App.css';
 const initialValues = {
 	weight: '',
 	height: '',
-	date: '',
+	date: ''
 }
-
 const restrictKeyList = ['-', '+'];
 
 const BmiForm = ({ change }) => {
@@ -42,11 +41,11 @@ const BmiForm = ({ change }) => {
 				<div className="col m6 s12">
 					<label htmlFor="weight">Weight (in kg)</label>
 					<input
-						id="number1"
+						id="weight"
 						name="weight"
 						type="number"
-						max={999}
-						min={1}
+						max="999"
+						min="1"
 						placeholder="50"
 						value={state.weight}
 						onChange={(e) => handleChange(e)}


### PR DESCRIPTION
This PR address is my proposal of bug #44 Negative weight and height should not allow in user input.
I have added a function called filter input to validate user input on the event of keyDown.

```
const filterInput = (e, restrictKeyList) => {
		let isValidInput = restrictKeyList.some((key) => e.key === key);
		if (isValidInput) e.preventDefault();
	}
````
This small change will restrict users to enter any sign in input and solve issue #44.
