### PR TITLE
Reset lastState after undoing to hide Undo button

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -40,6 +40,7 @@ const App = () => {
 
   const handleUndo = () => {
     setState(getData('lastState'));
+    storeData('lastState', null);
   };
 
   return (


### PR DESCRIPTION
Currently, after Undo button is clicked and the last state before deleting has been restored, the subsequent Undo button click will not do anything. Suggest to to reset `lastState` after undoing to hide Undo button.